### PR TITLE
feat(CalendarList): add custom month renderer

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -51,7 +51,9 @@ class CalendarList extends Component {
     /** Whether to use static header that will not scroll with the list (horizontal only) */
     staticHeader: PropTypes.bool,
     /** A custom key extractor for the generated calendar months */
-    keyExtractor: PropTypes.func
+    keyExtractor: PropTypes.func,
+    /** Replace default month renderer with custom ones (receives XDate()) */
+    renderMonth: PropTypes.func
   }
 
   static defaultProps = {
@@ -217,6 +219,7 @@ class CalendarList extends Component {
         calendarWidth={this.props.horizontal ? this.props.calendarWidth : undefined} 
         {...this.props} 
         style={this.props.calendarStyle}
+        renderMonth={this.props.renderMonth}
       />
     );
   }

--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -85,6 +85,7 @@ class CalendarListItem extends Component {
           headerStyle={this.props.horizontal ? this.props.headerStyle : undefined}
           accessibilityElementsHidden={this.props.accessibilityElementsHidden} // iOS
           importantForAccessibility={this.props.importantForAccessibility} // Android
+          renderMonth={this.props.renderMonth}
         />
       );
     } else {

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -25,7 +25,8 @@ class CalendarHeader extends Component {
     onPressArrowRight: PropTypes.func,
     disableArrowLeft: PropTypes.bool,
     disableArrowRight: PropTypes.bool,
-    webAriaLevel: PropTypes.number
+    webAriaLevel: PropTypes.number,
+    renderMonth: PropTypes.func
   };
 
   static defaultProps = {
@@ -76,6 +77,9 @@ class CalendarHeader extends Component {
       return true;
     }
     if (nextProps.disableArrowRight !== this.props.disableArrowRight) {
+      return true;
+    }
+    if (nextProps.renderMonth !== this.props.renderMonth) {
       return true;
     }
     return false;
@@ -138,6 +142,20 @@ class CalendarHeader extends Component {
       );
     }
 
+    let renderMonth;
+    if (this.props.renderMonth) {
+      renderMonth = this.props.renderMonth;
+    } else {
+      renderMonth = (month) => (
+        <Text
+          allowFontScaling={false}
+          style={this.style.monthText}
+          {...webProps}>
+          {month}
+        </Text>
+      );
+    }
+
     let indicator;
     if (this.props.showIndicator) {
       indicator = <ActivityIndicator color={this.props.theme && this.props.theme.indicatorColor}/>;
@@ -162,14 +180,7 @@ class CalendarHeader extends Component {
         <View style={this.style.header}>
           {leftArrow}
           <View style={{flexDirection: 'row'}}>
-            <Text
-              allowFontScaling={false}
-              style={this.style.monthText}
-              {...webProps}
-              testID={testID ? `${HEADER_MONTH_NAME}-${testID}`: HEADER_MONTH_NAME}
-            >
-              {this.props.month.toString(this.props.monthFormat)}
-            </Text>
+            {renderMonth(this.props.month.toString(this.props.monthFormat))}
             {indicator}
           </View>
           {rightArrow}

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -84,7 +84,9 @@ class Calendar extends Component {
     /** Style passed to the header */
     headerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
     /** Provide aria-level for calendar heading for proper accessibility when used with web (react-native-web) */
-    webAriaLevel: PropTypes.number
+    webAriaLevel: PropTypes.number,
+    /** Custom month renderer */
+    renderMonth: PropTypes.func
   };
 
   constructor(props) {
@@ -328,6 +330,7 @@ class Calendar extends Component {
           webAriaLevel={this.props.webAriaLevel}
           disableArrowLeft={this.props.disableArrowLeft}
           disableArrowRight={this.props.disableArrowRight}
+          renderMonth={this.props.renderMonth}
         />
         <View style={this.style.monthView}>{weeks}</View>
       </View>);


### PR DESCRIPTION
Add a custom month renderer for Calendar and CalendarList. The `renderMonth` prop is a function that takes the formatted current month string as argument and returns with the custom View.